### PR TITLE
Fixed service routing for loadgenerator deployment. 

### DIFF
--- a/traffic-generator/loadgen.yaml
+++ b/traffic-generator/loadgen.yaml
@@ -13,7 +13,6 @@ spec:
       port: 8089
   selector:
     app: loadgenerator
-    service: loadgenerator
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,6 +45,8 @@ spec:
       - name: main
         image: docker.io/vmwareallspark/acme-load-gen:latest
         imagePullPolicy: Always
+        ports:
+        - containerPort: 8089
         env:
         - name: FRONTEND_ADDR
           value: "frontend:3000"


### PR DESCRIPTION
 Service selector didn't resolve.  Container port for deployment wasn't defined.

Allows a user to setup an ingress rule to access locust UI instead of using `kubectl port-forward`